### PR TITLE
retry intervals

### DIFF
--- a/lib/delayed/backend/sqs.rb
+++ b/lib/delayed/backend/sqs.rb
@@ -64,7 +64,8 @@ module Delayed
 
           @msg.delete if @msg
 
-          sqs.queues.named(queue_name).send_message(payload, :delay_seconds  => @delay)
+          maxed_delay = [900, @delay + 5 + attempts ** 4].min
+          sqs.queues.named(queue_name).send_message(payload, :delay_seconds  => maxed_delay )
           true
         end
 


### PR DESCRIPTION
uses the default delay formula from dj and uses the aws sqs send message option delay_seconds to actually delay retries.

sqs does not support delays over 15min (900s)
