### PR TITLE
Unfreeze aws-sdk version

### DIFF
--- a/delayed_job_sqs.gemspec
+++ b/delayed_job_sqs.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.files         = `git ls-files`.split($/)
   s.test_files    = s.files.grep(%r{^(test|spec|features)/})
 
-  s.add_dependency("aws-sdk", "1.11.1")
+  s.add_dependency("aws-sdk", "~> 1.11")
   s.add_dependency("delayed_job", ">= 3.0.0")
 
   s.add_development_dependency "rspec"


### PR DESCRIPTION
Seems to work fine with the latest gem version. POSTs to SQS are unacceptably slow in our project; this is one of a couple things that might fix that.
