### PR TITLE
Compress large messages to comply with sqs's 256 byte limit

### DIFF
--- a/lib/delayed/backend/sqs.rb
+++ b/lib/delayed/backend/sqs.rb
@@ -23,7 +23,7 @@ module Delayed
 
           if data.is_a?(AWS::SQS::ReceivedMessage)
             @msg = data
-            data = JSON.load(data.body)
+            data = ::DelayedJobSqs::Document.sqs_safe_json_load(data.body)
           end
 
           data.symbolize_keys!
@@ -60,7 +60,7 @@ module Delayed
           if @attributes[:handler].blank?
             raise "Handler missing!"
           end
-          payload = JSON.dump(@attributes)
+          payload = ::DelayedJobSqs::Document.sqs_safe_json_dump(@attributes)
 
           @msg.delete if @msg
 

--- a/lib/delayed/serialization/sqs.rb
+++ b/lib/delayed/serialization/sqs.rb
@@ -1,6 +1,38 @@
 # encoding: utf-8
 
+require 'zlib'
+require 'json' unless defined?(JSON)
+require 'base64'
+
 module DelayedJobSqs
   module Document
+    MAX_SQS_MESSAGE_SIZE_IN_BYTES = 2**18
+
+    def self.sqs_safe_json_dump(obj)
+      json = JSON.dump(obj)
+      if json.bytesize >= MAX_SQS_MESSAGE_SIZE_IN_BYTES
+        JSON.dump( dj_compressed_document: compress(json) )
+      else
+        json
+      end
+    end
+
+    def self.sqs_safe_json_load(json)
+      obj = JSON.load(json)
+      if obj.is_a?(Hash) && obj.key?('dj_compressed_document')
+        JSON.load(decompress(obj['dj_compressed_document']))
+      else
+        obj
+      end
+    end
+
+    def self.compress(string)
+      Base64.encode64(Zlib::Deflate.deflate(string))
+    end
+
+    def self.decompress(string)
+      Zlib::Inflate.inflate(Base64.decode64(string))
+    end
+
   end
 end

--- a/spec/serialization_spec.rb
+++ b/spec/serialization_spec.rb
@@ -1,0 +1,27 @@
+require_relative '../lib/delayed/serialization/sqs'
+
+describe(DelayedJobSqs::Document) do
+
+  it 'serializes and deserializes an array' do
+    array = ['a', 'b']
+    serialized_array = described_class.sqs_safe_json_dump(array)
+    deserialized_array = described_class.sqs_safe_json_load(serialized_array)
+    expect(deserialized_array).to eq(array)
+  end
+
+  it 'serializes and deserializes a hash' do
+    hash = { 'a' => 'b' }
+    serialized_hash = described_class.sqs_safe_json_dump(hash)
+    deserialized_hash = described_class.sqs_safe_json_load(serialized_hash)
+    expect(deserialized_hash).to eq(hash)
+  end
+
+  it 'serializes and deserializes a large array using compression' do
+    array = ['a', 'b'] * 2**18
+    serialized_array = described_class.sqs_safe_json_dump(array)
+    expect(serialized_array.bytesize).to be < 2**18
+    deserialized_array = described_class.sqs_safe_json_load(serialized_array)
+    expect(deserialized_array).to eq(array)
+  end
+
+end


### PR DESCRIPTION
We're seeing occasional errors when we try to stuff too big of an object into our delayed jobs queue. While we're also going to try to shrink those messages, there's no reason we can't compress the payload. This detects when the payload exceeds the limit, compresses it using DEFLATE, and then Base64 encodes it for JSON-friendliness.

@PoloPro @DMcKinnon-mdsol please review when convenient.