### PR TITLE
[MCC-288584] Batch upload block

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,3 +3,7 @@
 ## 0.2.0
 
 * Adds support for bulk messaging to SQS.
+
+## 0.2.1
+
+* Adds `batch_delay_jobs` method, a common usage pattern for buffer usage. 

--- a/README.md
+++ b/README.md
@@ -91,7 +91,15 @@ Finally, you may explicitly clear the buffer at any time with:
 Delayed::Job.clear_buffer!
 ```
 
-
+Or simply wrap your transaction with `batch_delay_jobs`
+```ruby
+Delayed::Job.batch_delay_jobs do
+  .
+  .
+  .
+end
+# => Sends generated SQS messages in batch, then stops buffering.
+```
 
 ## Start worker process
 

--- a/lib/delayed/backend/version.rb
+++ b/lib/delayed/backend/version.rb
@@ -4,7 +4,7 @@ module Delayed
       @@version = nil
 
       def self.version
-        @@version ||= "0.2.0"
+        @@version ||= "0.2.1"
       end
     end
   end


### PR DESCRIPTION
@mdsol/team04 

At @DMcKinnon-mdsol's suggestion, I moved the `batch_delay_jobs` method into the gem itself, since there was technically nothing unique to dalton in this implementation.

I spent a couple hours banging on the specs in this repo to try to get them functional, but only managed to get them into a similar state as @masongup-mdsol's attempt (failure).